### PR TITLE
Add a caution about minification

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,11 @@ const ExtendableError = require('extendable-error-class');
 class MyError extends ExtendableError {
     constructor(m) {
         super(m);
+        
+        // Optional - ExtendableError sets `name` to your class's name itself,
+        // but minification, etc. can change that, so you may want to do it
+        // explicitly.
+        this.name = 'MyError';
     }
 }
 


### PR DESCRIPTION
I ran into a bug today where my `ExtendableError`-derived class didn't have the `name` I was expecting, because UglifyJS had changed the class / constructor name. (See notes on `keep_fnames` [here](https://github.com/mishoo/UglifyJS2).) This usage note might save someone else a bit of trouble.